### PR TITLE
Sitemap rewrite

### DIFF
--- a/sitemap.go
+++ b/sitemap.go
@@ -113,8 +113,9 @@ func XMLPageGen(pagename string) (XMLPage []byte, gz bool) {
 	if parts[0] == "" {
 		XMLResult = XMLPageGenGuilds()
 	} else {
+		fmt.Println(parts)
 		var guildID int
-		guildID, err := strconv.Atoi(parts[1])
+		guildID, err := strconv.Atoi(parts[0])
 		if err != nil {
 			return []byte(err.Error()), false
 		}

--- a/sitemap.go
+++ b/sitemap.go
@@ -68,7 +68,6 @@ func init() {
 }
 
 func XMLServe(w http.ResponseWriter, r *http.Request, pagename string) {
-	// TODO: caching system
 	var XMLPage []byte
 	var gz bool
 	obj, ok := Caches[pagename]
@@ -147,26 +146,6 @@ func XMLPageGenGuilds() string {
 	for _, g := range guilds {
 		sitemapIndex.Push(Sitemap{
 			Location: fmt.Sprintf("https://dfs.ioi-xd.net/sitemap-%v.xml.gz", g.ID),
-		})
-	}
-	output, err := xml.Marshal(sitemapIndex)
-	if err != nil {
-		return err.Error()
-	}
-	XMLPage.Write([]byte(XMLSitemapPageHeader))
-	XMLPage.Write(output)
-	XMLPage.Write([]byte(XMLSitemapPageFooter))
-	return XMLPage.String()
-}
-
-func XMLPageGenGuildChannels(guildID snowflake.ID) string {
-	var XMLPage bytes.Buffer
-	var sitemapIndex SitemapIndex
-
-	channels := Client.GetForums(guildID)
-	for _, c := range channels {
-		sitemapIndex.Push(Sitemap{
-			Location: fmt.Sprintf("https://dfs.ioi-xd.net/sitemap-%v-%v.xml.gz", guildID, c.ID()),
 		})
 	}
 	output, err := xml.Marshal(sitemapIndex)

--- a/sitemap.go
+++ b/sitemap.go
@@ -129,7 +129,7 @@ func XMLPageGen(pagename string) (XMLPage []byte, gz bool) {
 		if err != nil {
 			return []byte(err.Error()), false
 		}
-		XMLResult = XMLPageGenGuildChannelThreads(snowflake.ID(guildID))
+		XMLResult = XMLPageGenThreads(snowflake.ID(guildID))
 	}
 	if gz {
 		return GZIPString(XMLResult), true
@@ -158,7 +158,7 @@ func XMLPageGenGuilds() string {
 	return XMLPage.String()
 }
 
-func XMLPageGenGuildChannelThreads(guildID snowflake.ID) string {
+func XMLPageGenThreads(guildID snowflake.ID) string {
 	var XMLPage bytes.Buffer
 	var urlIndex URLSet
 

--- a/sitemap.go
+++ b/sitemap.go
@@ -74,7 +74,7 @@ func XMLServe(w http.ResponseWriter, r *http.Request, pagename string) {
 		// Otherwise, search the cache.
 		lastUpdated := obj.LastUpdated
 		// If the time 30 minutes ago is greater then the updated time
-		if (time.Now().Unix() - int64(time.Minute*30)) > lastUpdated {
+		if (time.Now().Unix() - int64(time.Hour*6)) > lastUpdated {
 			// Update the cache
 			obj.XMLPage, obj.GZipped = XMLPageGen(pagename)
 			obj.LastUpdated = time.Now().Unix()

--- a/sitemap.go
+++ b/sitemap.go
@@ -113,7 +113,6 @@ func XMLPageGen(pagename string) (XMLPage []byte, gz bool) {
 	if parts[0] == "" {
 		XMLResult = XMLPageGenGuilds()
 	} else {
-		fmt.Println(parts)
 		var guildID int
 		guildID, err := strconv.Atoi(parts[0])
 		if err != nil {
@@ -181,6 +180,7 @@ func GZIPString(page string) (result []byte) {
 	var b bytes.Buffer
 	gzipWriter := gzip.NewWriter(&b)
 	_, err := gzipWriter.Write([]byte(page))
+	// todo: better error handling.
 	if err != nil {
 		fmt.Println(err)
 		return


### PR DESCRIPTION
PR that rewrites sitemap code to be cleaner.

- `encoding/xml` is used instead of writing the xml by hand, and it's written to a buffer instead of concatenated to a string.
- Some unused functions are removed.
- Cache time is 6 hours since Google apparently caches files for up to a day anyways.