### PR TITLE
Add top role as badge

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,8 @@ func main() {
 	state := state.New("Bot " + config.BotToken)
 	state.AddIntents(0 |
 		gateway.IntentGuildMessages |
-		gateway.IntentGuilds,
+		gateway.IntentGuilds |
+		gateway.IntentGuildMembers,
 	)
 	if err = state.Open(ctx); err != nil {
 		log.Fatalln("Error while opening gateway connection to Discord:", err)

--- a/message.go
+++ b/message.go
@@ -32,11 +32,12 @@ type Message struct {
 }
 
 type Author struct {
-	ID     discord.UserID
-	Name   string
-	Avatar string
-	Bot    bool
-	Role   string
+	ID        discord.UserID
+	Name      string
+	Avatar    string
+	Bot       bool
+	Role      string
+	RoleColor string
 }
 
 type MediaPreview struct {
@@ -108,6 +109,7 @@ func (s *server) author(m discord.Message) Author {
 		Bot:    m.Author.Bot,
 	}
 	var role string
+	var color string
 	mr, err := s.discord.Member(m.GuildID, m.Author.ID)
 	if err == nil {
 		for _, rid := range mr.RoleIDs {
@@ -117,6 +119,7 @@ func (s *server) author(m discord.Message) Author {
 			}
 			if rl.Hoist {
 				role = rl.Name
+				color = rl.Color.String()
 				break
 			}
 		}
@@ -124,6 +127,7 @@ func (s *server) author(m discord.Message) Author {
 		log.Println("Failed to get a member: ", err)
 	}
 	auth.Role = role
+	auth.RoleColor = color
 	return auth
 }
 

--- a/resources/static/style.css
+++ b/resources/static/style.css
@@ -119,6 +119,7 @@ nav a {
 .post {
     padding-top: 10px;
     overflow: visible;
+    width: 100%;
 }
 .post .author {
     background: #ddd;

--- a/resources/static/style.css
+++ b/resources/static/style.css
@@ -122,7 +122,7 @@ nav a {
 }
 .post .author {
     background: #ddd;
-    max-width: 30%;
+    max-width: 15%;
     min-width: 150px;
     margin-right: 10px;
     padding: 10px;
@@ -143,12 +143,14 @@ nav a {
     list-style-type: none;
     margin: 0;
     padding: 0;
+    text-align: center;
 }
 .post .badges li {
-    width: 1.5em;
     background: #bbb;
     padding: 4px;
     margin: 4px auto;
+    text-align: center;
+    display: inline-block;
 }
 .post .timestamp {
     padding: 4px;

--- a/resources/templates/post.gohtml
+++ b/resources/templates/post.gohtml
@@ -42,10 +42,10 @@
         <img class='small-avatar' src="{{.Author.Avatar}}">
         <div>{{.Author.Name}}</div>
         <img src="{{.Author.Avatar}}">
-        {{if .Author.Role}}
-            <div>{{.Author.Role}}</div>
-        {{end}}
         <ul class="badges">
+        {{if .Author.Role}}
+            <li {{if .Author.RoleColor}}style="box-shadow: inset 2px 2px {{.Author.RoleColor}}, inset -2px -2px {{.Author.RoleColor}};"{{end}}>{{.Author.Role}}</li>
+        {{end}}
         {{if .Author.Bot}}
             <li>BOT</li>
         {{end}}

--- a/resources/templates/post.gohtml
+++ b/resources/templates/post.gohtml
@@ -23,7 +23,7 @@
 <h2>{{.Post.Name}}</h2>
 
 {{if gt (len .MessageGroups) 0}}
-  {{$firstPost := (index (index .MessageGroups 0) 0)}}
+  {{$firstPost := (index (index .MessageGroups 0).Messages 0)}}
   {{$desc = (TrimForMeta $firstPost.Content)}}
   {{if $firstPost.MediaPreviews}}
         {{$image = (index $firstPost.MediaPreviews 0).Thumbnail}}
@@ -36,17 +36,20 @@
 
 <div>
 {{range .MessageGroups}}
-{{$firstMsg := (index . 0)}}
+{{$firstMsg := (index .Messages 0).Message}}
 <div class='post flex roworcolumn'>
     <div class='author flex column'>
-        <img class='small-avatar' src="{{(index . 0).Author.AvatarURL}}">
-        <div>{{$firstMsg.Author.Username}}</div>
-        <img src="{{(index . 0).Author.AvatarURL}}">
+        <img class='small-avatar' src="{{.Author.Avatar}}">
+        <div>{{.Author.Name}}</div>
+        <img src="{{.Author.Avatar}}">
+        {{if .Author.Role}}
+            <div>{{.Author.Role}}</div>
+        {{end}}
         <ul class="badges">
-        {{if $firstMsg.Author.Bot}}
+        {{if .Author.Bot}}
             <li>BOT</li>
         {{end}}
-        {{if eq $op $firstMsg.Author.ID}}
+        {{if eq $op .Author.ID}}
             <li>OP</li>
         {{end}}
         <span class='timestamp'>{{$firstMsg.ID.Time.Format "Jan 2 2006 3:04 PM"}}</time></span>
@@ -54,7 +57,7 @@
     </div>
     <div class='content'>
     <span class='timestamp'>Posted {{$firstMsg.ID.Time.Format "January 2, 2006 3:04 PM"}}</time></span>
-    {{range .}}
+    {{range .Messages}}
         {{.RenderedContent}}
         {{range .MediaPreviews}}
             <a href="{{.URL}}"><img src="{{.Thumbnail}}"></a>
@@ -67,19 +70,19 @@
             {{end}}
             </span>
         {{end}}
-        {{end}}
-            <span class='reactions'>
-                {{range $firstMsg.Reactions}}                            
-                    <span class='reaction'>
-                        {{if .Emoji.IsCustom}}
-                            <img class='emoji' src='https://cdn.discordapp.com/emojis/{{.Emoji.ID}}.png?size=40'>
-                        {{else}}
-                            {{.Emoji}}
-                        {{end}}
-                        <span class='count'>{{.Count}}</span>
-                    </span>
-                {{end}}
-            </span>
+    {{end}}
+        <span class='reactions'>
+            {{range $firstMsg.Reactions}}                            
+                <span class='reaction'>
+                    {{if .Emoji.IsCustom}}
+                        <img class='emoji' src='https://cdn.discordapp.com/emojis/{{.Emoji.ID}}.png?size=40'>
+                    {{else}}
+                        {{.Emoji}}
+                    {{end}}
+                    <span class='count'>{{.Count}}</span>
+                </span>
+            {{end}}
+        </span>
     </div>
 </div>
 {{end}}

--- a/server.go
+++ b/server.go
@@ -211,7 +211,7 @@ func (s *server) getPost(w http.ResponseWriter, r *http.Request) {
 		Guild         *discord.Guild
 		Forum         *discord.Channel
 		Post          *discord.Channel
-		MessageGroups [][]Message
+		MessageGroups []MessageGroup
 	}{guild, forum, post, nil}
 
 	msgs, err := s.discord.Client.Messages(post.ID, 0)
@@ -223,15 +223,17 @@ func (s *server) getPost(w http.ResponseWriter, r *http.Request) {
 	sort.Slice(msgs, func(i, j int) bool {
 		return msgs[i].ID < msgs[j].ID
 	})
-	var msgrps [][]Message
+	var msgrps []MessageGroup
 	i := -1
 	for _, m := range msgs {
+		m.GuildID = guild.ID
 		msg := s.message(m)
-		if i == -1 || msgrps[i][0].Author.ID != m.Author.ID {
-			msgrps = append(msgrps, []Message{msg})
+		if i == -1 || msgrps[i].Author.ID != m.Author.ID {
+			auth := s.author(m)
+			msgrps = append(msgrps, MessageGroup{auth, []Message{msg}})
 			i++
 		} else {
-			msgrps[i] = append(msgrps[i], msg)
+			msgrps[i].Messages = append(msgrps[i].Messages, msg)
 		}
 	}
 	ctx.MessageGroups = msgrps


### PR DESCRIPTION
Appears alongside the BOT and/or OP badges (if present) and has an outline corresponding to the role color. Also adds the Guild Members privileged intent to speed up getting role data.
![image](https://user-images.githubusercontent.com/21112968/192359590-248c0924-c295-44fd-b25a-48ae50e0b2c3.png)
